### PR TITLE
display inline code properly

### DIFF
--- a/bootdoc.css
+++ b/bootdoc.css
@@ -47,6 +47,10 @@
 	font-family: "Consolas", "Bitstream Vera Sans Mono", "Andale Mono", "Monaco", "DejaVu Sans Mono", "Lucida Console", "monospace";
 }
 
+.d_inline_code {
+    padding: 0px;
+}
+
 [class*='ddoc-icon-'] {
 	display: inline-block;
 	width: 16px;


### PR DESCRIPTION
just a small fix, that makes `pre` inline again.
